### PR TITLE
[PR] Handle Only Active Players

### DIFF
--- a/src/pysc2_evolved/lib/replay/replay_observation_stream.py
+++ b/src/pysc2_evolved/lib/replay/replay_observation_stream.py
@@ -17,10 +17,11 @@ import io
 import json
 import logging
 import time
-from typing import List
+from typing import Generator, List
 
 import mpyq
 from s2clientprotocol import sc2api_pb2 as sc_pb
+from s2clientprotocol.sc2api_pb2 import ResponseObservation
 
 from pysc2_evolved import run_configs
 from pysc2_evolved.lib.remote_controller import RemoteController
@@ -200,7 +201,10 @@ class ReplayObservationStream(object):
     def static_data(self):
         return self._controllers[0].data()
 
-    def observations(self, step_sequence: List[int] | None = None):
+    def observations(
+        self,
+        step_sequence: List[int] | None = None,
+    ) -> Generator[ResponseObservation | List[ResponseObservation], None, None]:
         """
         Yields a ResponseObservation proto for each environment step.
 

--- a/src/pysc2_evolved/lib/replay/replay_observation_stream.py
+++ b/src/pysc2_evolved/lib/replay/replay_observation_stream.py
@@ -139,8 +139,15 @@ class ReplayObservationStream(object):
                 proc.close()
         self._sc2_procs = []
 
-    def start_replay_from_data(self, replay_data: bytes, player_id: int):
-        """Starts the stream of replay observations from an in-memory replay."""
+    def start_replay_from_data(
+        self,
+        replay_data: bytes,
+        player_id: int,
+        opponent_id: int | None,
+    ):
+        """
+        Starts the stream of replay observations from an in-memory replay.
+        """
         self._player_id = player_id
 
         try:
@@ -149,10 +156,13 @@ class ReplayObservationStream(object):
             logging.exception("Error getting replay version from data: %s", err)
             raise ReplayError(err)
 
-        if self._add_opponent_observations:
+        # Attempt to calculate the opponent ID if it was not supplied by the caller.
+        # This will most likely fail for any replay that has additional observers,
+        # referees or casters. It is an naive way to calculate the player_id.
+        if self._add_opponent_observations and not opponent_id:
             player_ids = [player_id, (player_id % 2) + 1]
         else:
-            player_ids = [player_id]
+            player_ids = [player_id, opponent_id]
         start_requests = []
         for p_id in player_ids:
             start_requests.append(

--- a/src/pysc2_evolved/lib/replay/sc2_replay.py
+++ b/src/pysc2_evolved/lib/replay/sc2_replay.py
@@ -24,9 +24,9 @@ from s2protocol import versions as s2versions
 
 def _convert_to_str(s):
     if isinstance(s, bytes):
-        return bytes.decode(s)
-    else:
-        return s
+        decoded_bytes = bytes.decode(s, encoding="utf-8", errors="ignore")
+        return decoded_bytes
+    return s
 
 
 def _convert_all_to_str(structure):
@@ -55,9 +55,12 @@ class SC2Replay(object):
         )
 
     def init_data(self):
-        return _convert_all_to_str(
-            self._protocol.decode_replay_initdata(self._extracted[b"replay.initData"])
-        )
+        extracted = self._extracted[b"replay.initData"]
+        decoded = self._protocol.decode_replay_initdata(extracted)
+
+        string = _convert_all_to_str(structure=decoded)
+
+        return string
 
     def tracker_events(self, filter_fn=None):
         """Yield tracker events from the replay in s2protocol format."""
@@ -115,11 +118,15 @@ def _extract(contents):
     replay_io.seek(0)
     archive = mpyq.MPQArchive(replay_io)
     extracted = archive.extract()
-    metadata = json.loads(bytes.decode(extracted[b"replay.gamemetadata.json"], "utf-8"))
+
+    replay_game_metadata = extracted[b"replay.gamemetadata.json"]
+    decoded_replay_game_metadata = bytes.decode(replay_game_metadata, encoding="utf-8")
+
+    metadata_loaded_from_json = json.loads(decoded_replay_game_metadata)
     contents = archive.header["user_data_header"]["content"]
     header = s2versions.latest().decode_replay_header(contents)
     base_build = header["m_version"]["m_baseBuild"]
     protocol = s2versions.build(base_build)
     if protocol is None:
         raise ValueError("Could not load protocol {} for replay".format(base_build))
-    return header, metadata, extracted, protocol
+    return header, metadata_loaded_from_json, extracted, protocol

--- a/src/pysc2_evolved/lib/replay/sc2_replay_utils.py
+++ b/src/pysc2_evolved/lib/replay/sc2_replay_utils.py
@@ -15,7 +15,7 @@
 
 import collections
 import dataclasses
-from typing import List, Mapping, Set
+from typing import Any, Dict, List, Mapping
 
 from pysc2_evolved.lib.replay import sc2_replay
 
@@ -50,33 +50,119 @@ class EventData:
 
 @dataclasses.dataclass
 class PlayerIDs:
-    user_id: int
-    player_id: int
-    slot_id: int
+    player_name: str | None = None
+    player_toon: str | None = None
+    user_id: int | None = None
+    player_id: int | None = None
+    slot_id: int | None = None
+
+    def __hash__(self):
+        return hash(
+            (
+                self.player_name,
+                self.player_toon,
+                self.user_id,
+                self.player_id,
+                self.slot_id,
+            )
+        )
 
 
-def get_active_players(replay: sc2_replay.SC2Replay) -> Set[PlayerIDs]:
-    user_id_set = set()
+def get_detail_player_list(replay: sc2_replay.SC2Replay) -> List[Dict[str, Any]]:
+    details = replay.details()
+    details_player_list = details["m_playerList"]
+    for player in details_player_list:
+        toon_object = player["m_toon"]
+        region = toon_object["m_region"]
+        program_id = toon_object["m_programId"][-2:]
+        realm = toon_object["m_realm"]
+        m_id = toon_object["m_id"]
+
+        toon_string = f"{region}-{program_id}-{realm}-{m_id}"
+        player["m_toon"] = toon_string
+
+    return details_player_list
+
+
+def get_init_data_slot_list(replay: sc2_replay.SC2Replay) -> List[Dict[str, Any]]:
+    init_data = replay.init_data()
+    init_data_sync_lobby_state = init_data["m_syncLobbyState"]
+    init_data_lobby_state = init_data_sync_lobby_state["m_lobbyState"]
+    init_data_slots = init_data_lobby_state["m_slots"]
+
+    return init_data_slots
+
+
+def get_nickname_from_toon(
+    slot_list: List[Dict[str, Any]],
+    details_player_list: List[Dict[str, Any]],
+) -> Dict[str, PlayerIDs]:
+    toon_to_player_dict = {}
+    for details_player in details_player_list:
+        player_toon = details_player["m_toon"]
+        player_name = details_player["m_name"]
+
+        toon_to_player_dict[player_toon] = PlayerIDs(
+            player_name=player_name, player_toon=player_toon
+        )
+
+    for index, slot_data in enumerate(slot_list):
+        slot_toon = slot_data["m_toonHandle"]
+        if slot_toon in toon_to_player_dict:
+            slot_index = index
+            user_id = slot_data["m_userId"]
+
+            toon_to_player_dict[slot_toon].slot_id = slot_index
+            toon_to_player_dict[slot_toon].user_id = user_id
+
+    return toon_to_player_dict
+
+
+def get_user_id_to_PlayerIDs_mapping(
+    toon_to_player_ids_mapping: Dict[str, PlayerIDs],
+) -> Dict[str, PlayerIDs]:
+    new_dict = dict()
+    for _, value in toon_to_player_ids_mapping.items():
+        new_dict[value.user_id] = value
+
+    return new_dict
+
+
+def get_active_players(replay: sc2_replay.SC2Replay) -> Dict[str, PlayerIDs]:
+    slots = get_init_data_slot_list(replay=replay)
+    details_player_list = get_detail_player_list(replay=replay)
+
+    toon_to_player_ids_mapping = get_nickname_from_toon(
+        slot_list=slots, details_player_list=details_player_list
+    )
+
+    user_id_to_object_mapping = get_user_id_to_PlayerIDs_mapping(
+        toon_to_player_ids_mapping=toon_to_player_ids_mapping
+    )
 
     for event in replay.tracker_events():
-        event_type = _readable_event_type(event["_event"])
+        # event_type = _readable_event_type(event["_event"])
+
+        event_type = event["_event"].split(".")[-1]
 
         # We are only interested in the PlayerSetup event.
         # This is important for the participating players more so than the observers.
-        if event_type != "PlayerSetup":
+        if event_type != "SPlayerSetupEvent":
             continue
 
         # This should be the user ID of the participating player:
-        user_id = event["_userid"]["m_userId"]
-        player_id = event["_userid"]["m_playerId"]
-        slot_id = event["_userid"]["m_slotId"]
+        user_id = event["m_userId"]
+        active_player_object = user_id_to_object_mapping[user_id]
 
-        if user_id not in user_id_set:
-            user_id_set.add(
-                PlayerIDs(user_id=user_id, player_id=player_id, slot_id=slot_id)
-            )
+        player_id = event["m_playerId"]
+        active_player_object.player_id = player_id
 
-    return user_id_set
+        # slot_id = event["m_slotId"]
+
+        # TODO: It is possible to get the user toon from the slot.
+        # But how do I get other user information such as nickname?
+
+    return user_id_to_object_mapping
 
 
 def raw_action_skips(replay: sc2_replay.SC2Replay) -> Mapping[int, List[int]]:
@@ -93,11 +179,7 @@ def raw_action_skips(replay: sc2_replay.SC2Replay) -> Mapping[int, List[int]]:
     last_game_loop = None
 
     # Acquiring only the active players without observers:
-    active_players = get_active_players(replay=replay)
-    active_user_id_to_player_id = {
-        player_object.user_id: player_object.player_id
-        for player_object in active_players
-    }
+    active_players_user_id_map = get_active_players(replay=replay)
 
     # Extract per-user events of interest.
     for event in replay.game_events():
@@ -114,17 +196,16 @@ def raw_action_skips(replay: sc2_replay.SC2Replay) -> Mapping[int, List[int]]:
             user_id = event["_userid"]["m_userId"]
             # player_id = user_id + 1
 
-            player_id = None
-            if player_id not in active_user_id_to_player_id:
-                # This is an observer or a referee.
-                # We can skip this event.
+            # We don't care about observers and other users for now:
+            if user_id not in active_players_user_id_map:
                 continue
-            player_id = active_user_id_to_player_id[user_id]
+
+            player_information = active_players_user_id_map[user_id]
+            player_id = player_information.player_id
 
             # REVIEW: Observers/referees can leave the game before.
             # We need to make sure that this pertains only to the active players.
             # As soon as anyone leaves, we stop tracking events.
-
             # We check if the user left only in case of active players.
             # We do not care if the observers leave the game:
             if event_type == "GameUserLeave":

--- a/src/pysc2_evolved/lib/replay/sc2_replay_utils.py
+++ b/src/pysc2_evolved/lib/replay/sc2_replay_utils.py
@@ -128,6 +128,14 @@ def get_user_id_to_PlayerIDs_mapping(
     return new_dict
 
 
+def get_player_ids(user_id_to_object_mapping: Dict[int, PlayerIDs]):
+    player_id_to_info_mapping = {}
+    for _, player_ids in user_id_to_object_mapping.items():
+        player_id_to_info_mapping[player_ids.player_id] = player_ids
+
+    return player_id_to_info_mapping
+
+
 def get_active_players(replay: sc2_replay.SC2Replay) -> Dict[str, PlayerIDs]:
     slots = get_init_data_slot_list(replay=replay)
     details_player_list = get_detail_player_list(replay=replay)

--- a/src/pysc2_evolved/lib/replay/sc2_replay_utils.py
+++ b/src/pysc2_evolved/lib/replay/sc2_replay_utils.py
@@ -15,7 +15,7 @@
 
 import collections
 import dataclasses
-from typing import List, Mapping
+from typing import List, Mapping, Set
 
 from pysc2_evolved.lib.replay import sc2_replay
 
@@ -48,6 +48,37 @@ class EventData:
     event_type: str
 
 
+@dataclasses.dataclass
+class PlayerIDs:
+    user_id: int
+    player_id: int
+    slot_id: int
+
+
+def get_active_players(replay: sc2_replay.SC2Replay) -> Set[PlayerIDs]:
+    user_id_set = set()
+
+    for event in replay.tracker_events():
+        event_type = _readable_event_type(event["_event"])
+
+        # We are only interested in the PlayerSetup event.
+        # This is important for the participating players more so than the observers.
+        if event_type != "PlayerSetup":
+            continue
+
+        # This should be the user ID of the participating player:
+        user_id = event["_userid"]["m_userId"]
+        player_id = event["_userid"]["m_playerId"]
+        slot_id = event["_userid"]["m_slotId"]
+
+        if user_id not in user_id_set:
+            user_id_set.add(
+                PlayerIDs(user_id=user_id, player_id=player_id, slot_id=slot_id)
+            )
+
+    return user_id_set
+
+
 def raw_action_skips(replay: sc2_replay.SC2Replay) -> Mapping[int, List[int]]:
     """
     Returns player id -> list, the game loops on which each player acted.
@@ -60,20 +91,48 @@ def raw_action_skips(replay: sc2_replay.SC2Replay) -> Mapping[int, List[int]]:
     """
     action_frames = collections.defaultdict(list)
     last_game_loop = None
+
+    # Acquiring only the active players without observers:
+    active_players = get_active_players(replay=replay)
+    active_user_id_to_player_id = {
+        player_object.user_id: player_object.player_id
+        for player_object in active_players
+    }
+
     # Extract per-user events of interest.
     for event in replay.game_events():
         event_type = _readable_event_type(event["_event"])
         if event_type not in _EVENT_TYPES_TO_FILTER_OUT:
             game_loop = event["_gameloop"]
             last_game_loop = game_loop
+
+            # TODO:
+            # REVIEW: This only works for replays that have two players.
+            # Need to verify that the observerss or other users are always with
+            # ID above 2, then it is safe to say that such events can be skipped.
+            # Then there would be no need to raise this exception.
+            user_id = event["_userid"]["m_userId"]
+            # player_id = user_id + 1
+
+            player_id = None
+            if player_id not in active_user_id_to_player_id:
+                # This is an observer or a referee.
+                # We can skip this event.
+                continue
+            player_id = active_user_id_to_player_id[user_id]
+
+            # REVIEW: Observers/referees can leave the game before.
+            # We need to make sure that this pertains only to the active players.
             # As soon as anyone leaves, we stop tracking events.
+
+            # We check if the user left only in case of active players.
+            # We do not care if the observers leave the game:
             if event_type == "GameUserLeave":
                 break
 
-            user_id = event["_userid"]["m_userId"]
-            player_id = user_id + 1
-            if player_id < 1 or player_id > 2:
-                raise ValueError(f"Unexpected player_id: {player_id}")
+            # REVIEW: This check is not true for replays with observers:
+            # if player_id < 1 or player_id > 2:
+            #     raise ValueError(f"Unexpected player_id: {player_id}")
             if (
                 action_frames[player_id]
                 and action_frames[player_id][-1].game_loop == game_loop

--- a/src/pysc2_evolved/settings.py
+++ b/src/pysc2_evolved/settings.py
@@ -1,4 +1,4 @@
 LOGGING_FORMAT = "[%(asctime)s][%(process)d/%(thread)d][%(levelname)s][%(filename)s:%(lineno)s] - %(message)s"
 
 # Controls the timeout for connecting to the game via websockets:
-TIMEOUT_SECONDS = 20
+TIMEOUT_SECONDS = 60


### PR DESCRIPTION
Adjusted parts of the `replay_observation_stream`, and other parts of code that were making assumptions upon player IDs. The code now discovers the active players within the replay and makes observations.